### PR TITLE
explicitly requiring Open3

### DIFF
--- a/lib/carrierwave/video/thumbnailer/ffmpegthumbnailer.rb
+++ b/lib/carrierwave/video/thumbnailer/ffmpegthumbnailer.rb
@@ -1,4 +1,5 @@
 require 'carrierwave/video/thumbnailer/ffmpegthumbnailer/options'
+require 'open3'
 
 module CarrierWave
   module Video


### PR DESCRIPTION
i was getting

```
Failure/Error: Unable to find matching line from backtrace
     ActiveRecord::RecordInvalid:
       Validation failed: File Failed to thumbnail with ffmpegthumbnailer. Check ffmpegthumbnailer install and verify video is not corrupt. Original error: uninitialized constant CarrierWave::Video::Thumbnailer::FFMpegThumbnailer::Open3, File Failed to thumbnail with ffmpegthumbnailer. Check ffmpegthumbnailer install and verify video is not corrupt. 
Original error: uninitialized constant CarrierWave::Video::Thumbnailer::FFMpegThumbnailer::Open3
```

and this _may_ be solved by

``` ruby
require 'open3'
...
```

in `MyUploader` of my project, but it would be great if you require the needed class explicitly where it is used

thanks!
