### PR TITLE
Enclosed input and output paths in double quotes

### DIFF
--- a/lib/carrierwave/video/thumbnailer/ffmpegthumbnailer.rb
+++ b/lib/carrierwave/video/thumbnailer/ffmpegthumbnailer.rb
@@ -41,7 +41,7 @@ module CarrierWave
 
         def run options
           logger = options.logger
-          cmd = %Q{#{CarrierWave::Video::Thumbnailer::FFMpegThumbnailer.binary} -i #{input_path} -o #{output_path} #{options.to_cli}}.rstrip
+          cmd = %Q{#{CarrierWave::Video::Thumbnailer::FFMpegThumbnailer.binary} -i "#{input_path}" -o "#{output_path}" #{options.to_cli}}.rstrip
 
             logger.info("Running....#{cmd}") if logger
             outputs = []


### PR DESCRIPTION
Enclosed input and output path arguments in double quotes allowing for paths which include spaces when calling the ffmpegthumbnailer command.
