### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ manual:
 
   * format: 'jpg' or 'png' ('jpg' is the default).
   * quality:  compression quality (1 to 10, default is 8).
-  * size: thumbnail length in pixels (defaults to 128).
+  * size: thumbnail width in pixels (defaults to 128) (default keep initial aspect ratio).
   * strip: movie film strip decoration (defaults to `false`).
   * seek: where to take the snapshot. May be specified as HH:MM:SS or X%.
     Defaults to 10%.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Runs `ffmpegthumbnailer` with CLI keys provided by your configuration or just
 uses quite a reasonable ffmpegthumbnailer's defaults. See Examples section for
 details.
 
+* macOS: you can run `brew install ffmpegthumbnailer`
+
 ## Examples
 
 Here's a working example:


### PR DESCRIPTION
1. Add one line in document for install `ffmpegthumbnailer` macOS. work for me.
2. Improve document about 'size' options. ( 'length' may be confused, 'width' is more precise)

Thank you for writing this gem. very useful.